### PR TITLE
Add Become a partner link to topbar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.17.3
+   2.3.26

--- a/layouts/head.html
+++ b/layouts/head.html
@@ -35,6 +35,9 @@
 
           <div class="collapse navbar-collapse" id="navigation">
             <ul class="nav navbar-nav navbar-right">
+              <li>
+                <a href="https://share.hsforms.com/1z4oOPKI6STG4UkfmpwJuTg312g0" target="_blank">Become a partner</a>
+              </li>
               <li class="<%= "active" if @item_rep.path.start_with?("/guides/") %>">
                 <a href="/guides/">Guides</a>
               </li>


### PR DESCRIPTION
Add Become a partner link:

![BookingSync API documentation 2023-11-30 at 10 48 54 AM](https://github.com/BookingSync/channel-api-docs/assets/107466590/9638ed7d-1c0a-4786-a0a0-3055afac90a5)
